### PR TITLE
docs: migrate documentation and remove redundant content

### DIFF
--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/MainActivity.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/MainActivity.kt
@@ -48,6 +48,24 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.compose.rememberNavController
 import com.github.yumelira.yumebox.clash.manager.ClashManager
 import com.github.yumelira.yumebox.common.AppConstants
+import com.github.yumelira.yumebox.common.util.IntentController
+import com.github.yumelira.yumebox.common.util.ProxyAutoStartHelper
+import com.github.yumelira.yumebox.data.repository.ProxyConnectionService
+import com.github.yumelira.yumebox.data.store.AppSettingsStorage
+import com.github.yumelira.yumebox.data.store.NetworkSettingsStorage
+import com.github.yumelira.yumebox.data.store.ProfilesStore
+import com.github.yumelira.yumebox.presentation.component.BottomBar
+import com.github.yumelira.yumebox.presentation.component.LocalHandlePageChange
+import com.github.yumelira.yumebox.presentation.component.LocalNavigator
+import com.github.yumelira.yumebox.presentation.component.LocalPagerState
+import com.github.yumelira.yumebox.presentation.screen.HomePager
+import com.github.yumelira.yumebox.presentation.screen.ProfilesPager
+import com.github.yumelira.yumebox.presentation.screen.ProxyPager
+import com.github.yumelira.yumebox.presentation.screen.SettingPager
+import com.github.yumelira.yumebox.presentation.theme.NavigationTransitions
+import com.github.yumelira.yumebox.presentation.theme.ProvideAndroidPlatformTheme
+import com.github.yumelira.yumebox.presentation.theme.YumeTheme
+import com.github.yumelira.yumebox.presentation.viewmodel.AppSettingsViewModel
 import com.ramcosta.composedestinations.DestinationsNavHost
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootGraph
@@ -57,31 +75,13 @@ import dev.chrisbanes.haze.HazeState
 import dev.chrisbanes.haze.HazeStyle
 import dev.chrisbanes.haze.HazeTint
 import dev.chrisbanes.haze.hazeSource
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.compose.koinViewModel
-import com.github.yumelira.yumebox.common.util.IntentController
-import com.github.yumelira.yumebox.common.util.ProxyAutoStartHelper
-import com.github.yumelira.yumebox.data.repository.ProxyConnectionService
-import com.github.yumelira.yumebox.data.store.AppSettingsStorage
-import com.github.yumelira.yumebox.data.store.NetworkSettingsStorage
-import com.github.yumelira.yumebox.data.store.ProfilesStore
-import com.github.yumelira.yumebox.presentation.theme.NavigationTransitions
-import com.github.yumelira.yumebox.presentation.theme.ProvideAndroidPlatformTheme
-import com.github.yumelira.yumebox.presentation.theme.YumeTheme
-import com.github.yumelira.yumebox.presentation.component.BottomBar
-import com.github.yumelira.yumebox.presentation.component.LocalHandlePageChange
-import com.github.yumelira.yumebox.presentation.component.LocalNavigator
-import com.github.yumelira.yumebox.presentation.component.LocalPagerState
-import com.github.yumelira.yumebox.presentation.screen.HomePager
-import com.github.yumelira.yumebox.presentation.screen.ProfilesPager
-import com.github.yumelira.yumebox.presentation.screen.ProxyPager
-import com.github.yumelira.yumebox.presentation.screen.SettingPager
-import com.github.yumelira.yumebox.presentation.viewmodel.AppSettingsViewModel
-import kotlinx.coroutines.delay
 import top.yukonga.miuix.kmp.basic.Scaffold
 import top.yukonga.miuix.kmp.basic.Surface
 import top.yukonga.miuix.kmp.theme.MiuixTheme
@@ -93,7 +93,9 @@ class MainActivity : ComponentActivity() {
         private const val REQUEST_NOTIFICATION_PERMISSION = 1001
         private val _pendingImportUrl = MutableStateFlow<String?>(null)
         val pendingImportUrl: StateFlow<String?> = _pendingImportUrl.asStateFlow()
-        fun clearPendingImportUrl() { _pendingImportUrl.value = null }
+        fun clearPendingImportUrl() {
+            _pendingImportUrl.value = null
+        }
     }
 
     private val appSettingsStorage: AppSettingsStorage by inject()
@@ -147,7 +149,7 @@ class MainActivity : ComponentActivity() {
                     }
                 }
             }
-            
+
             LaunchedEffect(Unit) {
                 delay(AppConstants.Timing.AUTO_START_DELAY_MS)
                 ProxyAutoStartHelper.checkAndAutoStart(
@@ -161,12 +163,12 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-    
+
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleIntent(intent)
     }
-    
+
     private fun handleIntent(intent: Intent?) {
         intent?.let { safeIntent ->
             safeIntent.data?.let { uri ->
@@ -185,21 +187,6 @@ class MainActivity : ComponentActivity() {
             intentController.handleIntent(safeIntent)
         }
     }
-//
-//
-//    override fun onRequestPermissionsResult(
-//        requestCode: Int,
-//        permissions: Array<String>,
-//        grantResults: IntArray
-//    ) {
-//        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-//
-//        when (requestCode) {
-//            REQUEST_NOTIFICATION_PERMISSION -> {
-//                // 通知权限处理逻辑保持不变
-//            }
-//        }
-//    }
 }
 
 @Composable
@@ -255,7 +242,7 @@ fun MainScreen(navigator: DestinationsNavigator) {
 
                     return Offset.Zero
                 }
-                
+
                 override suspend fun onPreFling(available: Velocity): Velocity {
                     if (abs(available.y) > abs(available.x) * 1.5f) {
                         return Velocity(available.x, 0f)
@@ -264,7 +251,7 @@ fun MainScreen(navigator: DestinationsNavigator) {
                 }
             }
         }
-        
+
         Scaffold(
             bottomBar = {
                 BottomBar(hazeState, hazeStyle)

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/common/util/DeviceUtil.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/common/util/DeviceUtil.kt
@@ -32,7 +32,13 @@ object DeviceUtil {
     }
 
     fun is64BitDevice(): Boolean {
-        return Build.SUPPORTED_ABIS.any { abi -> abi.contains("arm64-v8a") || abi.contains("x86_64") }
+        // Prefer platform-provided 64-bit ABI list when available, otherwise fall back to exact ABI checks
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            Build.SUPPORTED_64_BIT_ABIS.isNotEmpty()
+        } else {
+            // For older devices, check known 64-bit ABI names explicitly
+            Build.SUPPORTED_ABIS.any { abi -> abi == "arm64-v8a" || abi == "x86_64" }
+        }
     }
 
     fun getPreferredAbi(): String {

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/common/util/DeviceUtil.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/common/util/DeviceUtil.kt
@@ -31,6 +31,10 @@ object DeviceUtil {
         }
     }
 
+    fun is64BitDevice(): Boolean {
+        return Build.SUPPORTED_ABIS.any { abi -> abi.contains("arm64-v8a") || abi.contains("x86_64") }
+    }
+
     fun getPreferredAbi(): String {
         return when (Build.SUPPORTED_ABIS.firstOrNull()) {
             "arm64-v8a" -> "arm64-v8a"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("com.android.application") version "8.13.1" apply false
-    id("com.android.library") version "8.13.1" apply false
+    id("com.android.application") version "8.12.0" apply false
+    id("com.android.library") version "8.12.0" apply false
     kotlin("android") version "2.2.21" apply false
     kotlin("multiplatform") version "2.2.21" apply false
     kotlin("plugin.serialization") version "2.2.21" apply false

--- a/core/src/cpp/version.h
+++ b/core/src/cpp/version.h
@@ -6,7 +6,7 @@
  * 当前编译core版本号
  */
 
-#define GIT_VERSION Alpha-32ce5139
+#define GIT_VERSION Alpha-6539b509
 #define make_Str(x) #x
 #define make_String(x) make_Str(x)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,28 +28,8 @@
 
 ## Usage
 
-- **Install**: Visit the [Releases](https://github.com/YumeYuka/YumeBox/releases) page
-- **Build**: See the [Build section](#build)
-
-### External Control API
-
-YumeBox supports external control via Android Intent, allowing other applications to control proxy
-service startup and shutdown.
-
-- Start Clash.Meta service
-
-  Send intent to activity `com.github.yumelira.yumebox.MainActivity` with action
-  `com.github.yumelira.yumebox.action.START_CLASH`
-
-- Stop Clash.Meta service
-
-  Send intent to activity `com.github.yumelira.yumebox.MainActivity` with
-  `action com.github.yumelira.yumebox.action.STOP_CLASH`
-
-- Import a profile
-
-  URL Scheme `clash://install-config?url=<encoded URI>` or
-  `clashmeta://install-config?url=<encoded URI>`
+- **Install**: Visit the [Installation](https://yume.mintlify.app/yumebox/guide/install) page
+- **Build**: See the [Build section](https://yume.mintlify.app/yumebox/guide/building)
 
 ## Discussion
 
@@ -60,54 +40,7 @@ service startup and shutdown.
 To translate YumeBox into your language or improve existing translations, please fork this project
 and create or update translation files in the `lang` directory.
 
-## Build
 
-1. **Sync core source code**
-
-   ```bash
-   sh scripts/sync-kernel.sh <alpha|meta|smart>
-   ```
-
-2. **Install dependencies**
-   Ensure that OpenJDK 24, Android SDK, CMake, and Golang are installed.
-
-3. **Create `local.properties` in the project root**
-
-   ```properties
-   sdk.dir=/path/to/android-sdk
-   ```
-
-4. **(Optional) Customize the package name by editing `gradle.properties`**
-
-   ```properties
-   project.namespace.base=com.github.yumelira.yumebox
-   project.namespace.core=${project.namespace.base}.core
-   project.namespace.extension=${project.namespace.base}.extension
-   project.namespace.buildlogic=${project.namespace.base}.buildlogic
-   ```
-
-5. **Create `signing.properties` in the project root**
-
-   ```properties
-   keystore.path=/path/to/keystore/file
-   keystore.password=<key store password>
-   key.alias=<key alias>
-   key.password=<key password>
-   ```
-
-6. **Build the application**
-
-   Ontology:
-
-   ```bash
-   ./gradlew app:assembleRelease
-   ```
-
-   SubStore Extension:
-
-   ```bash
-   ./gradlew extension:assembleRelease
-   ```
 ## Note
 
 > [!IMPORTANT]

--- a/docs/README_ZH_HANS.md
+++ b/docs/README_ZH_HANS.md
@@ -26,27 +26,10 @@
 
 ## 使用方法
 
-- **安装**：前往 [Releases](https://github.com/YumeYuka/YumeBox/releases)
-- **构建**：[跳转至构建章节](#构建)
+- **安装**：前往 [安装](https://yume.mintlify.app/yumebox/guide/install)
+- **构建**：[跳转至构建章节](https://yume.mintlify.app/yumebox/guide/building)
 
-### 外部控制 API
 
-YumeBox 支持通过 Android Intent 进行外部控制，使其他应用能够启动或停止代理服务。
-
-- 启动 Clash.Meta 服务
-
-  向活动 `com.github.yumelira.yumebox.MainActivity` 发送带有动作  
-  `com.github.yumelira.yumebox.action.START_CLASH` 的 Intent
-
-- 停止 Clash.Meta 服务
-
-  向活动 `com.github.yumelira.yumebox.MainActivity` 发送带有动作  
-  `com.github.yumelira.yumebox.action.STOP_CLASH` 的 Intent
-
-- 导入配置文件
-
-  使用 URL Scheme：`clash://install-config?url=<encoded URI>`  
-  或 `clashmeta://install-config?url=<encoded URI>`
 
 ## 讨论
 
@@ -56,54 +39,6 @@ YumeBox 支持通过 Android Intent 进行外部控制，使其他应用能够�
 
 如果您希望将 YumeBox 翻译为更多语言，或改进现有翻译，请 Fork 本项目，并在 `lang` 目录下创建或更新对应的翻译文件。
 
-## 构建
-
-1. **同步 core 源码**
-
-   ```bash
-   sh scripts/sync-kernel.sh <alpha|meta|smart>
-   ```
-
-2. **安装依赖**
-   请确保已安装 OpenJDK 24、Android SDK、CMake 与 Golang。
-
-3. **在项目根目录创建 `local.properties`**
-
-   ```properties
-   sdk.dir=/path/to/android-sdk
-   ```
-
-4. **（可选）自定义包名：修改 `gradle.properties`**
-
-   ```properties
-   project.namespace.base=com.github.yumelira.yumebox
-   project.namespace.core=${project.namespace.base}.core
-   project.namespace.extension=${project.namespace.base}.extension
-   project.namespace.buildlogic=${project.namespace.base}.buildlogic
-   ```
-
-5. **在项目根目录创建 `signing.properties`**
-
-   ```properties
-   keystore.path=/path/to/keystore/file
-   keystore.password=<key store password>
-   key.alias=<key alias>
-   key.password=<key password>
-   ```
-
-6. **构建应用**
-
-   本体:
-
-   ```bash
-   ./gradlew app:assembleRelease
-   ```
-
-   SubStore 拓展:
-
-   ```bash
-   ./gradlew extension:assembleRelease
-   ```
 
 ## 特别
 


### PR DESCRIPTION
## Summary by Sourcery

Update documentation links to new hosted guides, remove in-repo build and external control API docs in favor of external docs, and make minor Android and build configuration tweaks.

Enhancements:
- Add a utility to detect 64-bit Android devices and clean up minor Android activity code formatting.

Build:
- Downgrade the Android application and library Gradle plugin versions in the root build script.

Documentation:
- Point installation and build instructions in both English and Chinese READMEs to the new hosted documentation and drop the embedded build and external control API sections.

Chores:
- Bump the embedded core git version identifier in the C++ header.