### PR TITLE
Update User-agent

### DIFF
--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/common/util/DownloadUtil.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/common/util/DownloadUtil.kt
@@ -55,7 +55,7 @@ data class SubscriptionInfo(
 )
 
 object DownloadUtil {
-    private const val USER_AGENT = "Clash.Meta"
+    private const val USER_AGENT = "YumeBox/$versionName clash.meta/$versionName mihomo/$versionName"
     private const val UPDATE_INTERVAL_MS = 500L
 
     private fun parseFilenameFromContentDisposition(headers: Headers): String? {

--- a/core/src/golang/native/config/fetch.go
+++ b/core/src/golang/native/config/fetch.go
@@ -42,7 +42,7 @@ func GetCustomUserAgent() string {
 	if customUserAgent != "" {
 		return customUserAgent
 	}
-	return "clash.meta/" + app.VersionName()
+	return "YumeBox/" + app.VersionName() + " clash.meta/" + app.VersionName() + " mihomo/" + app.VersionName()
 }
 
 func openUrl(ctx context.Context, url string) (io.ReadCloser, error) {


### PR DESCRIPTION
## Summary by Sourcery

Update the default User-Agent string used for downloads and config fetching to identify the app as YumeBox alongside clash.meta and mihomo, all tagged with the current version name.