### PR TITLE
Revert "refactor(core): remove unused code and simplify data flow"

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -174,8 +174,6 @@ android {
         }
     }
 
-    val releaseSigningConfig = signingConfigs.findByName("release")
-
     buildTypes {
         debug {
             isMinifyEnabled = false
@@ -189,7 +187,7 @@ android {
             isShrinkResources = true
             isDebuggable = false
             isJniDebuggable = false
-            signingConfig = releaseSigningConfig
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/data/repository/ProxyConnectionService.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/data/repository/ProxyConnectionService.kt
@@ -65,7 +65,7 @@ class ProxyConnectionService(
         }
     }
 
-    fun startDirect(
+    suspend fun startDirect(
         profileId: String,
         mode: ProxyMode
     ): Result<Unit> {
@@ -116,7 +116,7 @@ class ProxyConnectionService(
         }
     }
 
-    private fun startProxyInternal(profileId: String, proxyMode: ProxyMode) {
+    private suspend fun startProxyInternal(profileId: String, proxyMode: ProxyMode) {
         val result = startDirect(
             profileId = profileId,
             mode = proxyMode

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/data/store/ProfilesStore.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/data/store/ProfilesStore.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.flow.stateIn
 
 class ProfilesStore(
     mmkv: MMKV,
-    scope: CoroutineScope
+    private val scope: CoroutineScope
 ) : MMKVPreference(externalMmkv = mmkv) {
 
     private val _profiles: Preference<List<Profile>> by jsonListFlow(
@@ -43,21 +43,25 @@ class ProfilesStore(
 
     val profiles: StateFlow<List<Profile>> = _profiles.state
 
+    val enabledProfile: StateFlow<Profile?> = _profiles.state
+        .map { list -> list.firstOrNull { it.enabled } }
+        .stateIn(scope, SharingStarted.WhileSubscribed(5000), getEnabledProfile())
+
     val recommendedProfile: StateFlow<Profile?> = _profiles.state
         .map { list -> list.firstOrNull { it.enabled } ?: list.firstOrNull() }
         .stateIn(scope, SharingStarted.WhileSubscribed(5000), getRecommendedProfile())
 
     fun getAllProfiles(): List<Profile> = _profiles.value
 
-     fun addProfile(profile: Profile) {
+    suspend fun addProfile(profile: Profile) {
         _profiles.add(profile)
     }
 
-     fun removeProfile(id: String) {
+    suspend fun removeProfile(id: String) {
         _profiles.remove { it.id == id }
     }
 
-     fun updateProfile(profile: Profile) {
+    suspend fun updateProfile(profile: Profile) {
         _profiles.update({ it.id == profile.id }) { profile }
     }
 
@@ -68,4 +72,6 @@ class ProfilesStore(
     fun getEnabledProfile(): Profile? = _profiles.value.firstOrNull { it.enabled }
 
     fun getRecommendedProfile(): Profile? = getEnabledProfile() ?: _profiles.value.firstOrNull()
+
+    fun hasEnabledProfile(): Boolean = _profiles.value.any { it.enabled }
 }

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/domain/facade/ProfilesRepository.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/domain/facade/ProfilesRepository.kt
@@ -25,8 +25,14 @@ import com.github.yumelira.yumebox.data.store.ProfilesStore
 import kotlinx.coroutines.flow.StateFlow
 
 class ProfilesRepository(
-    profilesStore: ProfilesStore
+    private val profilesStore: ProfilesStore
 ) {
     val profiles: StateFlow<List<Profile>> = profilesStore.profiles
+    val enabledProfile: StateFlow<Profile?> = profilesStore.enabledProfile
     val recommendedProfile: StateFlow<Profile?> = profilesStore.recommendedProfile
+
+    fun getAllProfiles(): List<Profile> = profilesStore.getAllProfiles()
+    fun getEnabledProfile(): Profile? = profilesStore.getEnabledProfile()
+    fun getRecommendedProfile(): Profile? = profilesStore.getRecommendedProfile()
+    fun hasEnabledProfile(): Boolean = profilesStore.hasEnabledProfile()
 }

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/domain/facade/ProxyFacade.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/domain/facade/ProxyFacade.kt
@@ -1,3 +1,23 @@
+/*
+ * This file is part of YumeBox.
+ *
+ * YumeBox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Copyright (c)  YumeLira 2025.
+ *
+ */
+
 package com.github.yumelira.yumebox.domain.facade
 
 import android.content.Intent
@@ -14,44 +34,110 @@ import com.github.yumelira.yumebox.domain.model.TrafficData
 import kotlinx.coroutines.flow.StateFlow
 import timber.log.Timber
 
+/**
+ * 代理外观
+ *
+ * 为 UI 层提供统一的代理操作接口
+ *
+ * 重构说明：
+ * - 代理组状态完全由 ProxyStateRepository 管理
+ * - 移除了手动刷新接口
+ * - 所有操作都是"设置"而非"刷新"
+ * - UI 只需观察状态流即可
+ */
 class ProxyFacade(
     private val clashManager: ClashManager,
     private val proxyConnectionService: ProxyConnectionService,
     private val selectionDao: SelectionDao
 ) {
+    // ========== 状态流 ==========
 
+    /**
+     * 代理状态
+     */
     val proxyState: StateFlow<ProxyState> = clashManager.proxyState
 
+    /**
+     * 是否正在运行
+     */
     val isRunning: StateFlow<Boolean> = clashManager.isRunning
 
+    /**
+     * 当前配置
+     */
     val currentProfile: StateFlow<Profile?> = clashManager.currentProfile
 
+    /**
+     * 实时流量
+     */
     val trafficNow: StateFlow<TrafficData> = clashManager.trafficNow
 
+    /**
+     * 总流量
+     */
     val trafficTotal: StateFlow<TrafficData> = clashManager.trafficTotal
 
+    /**
+     * 隧道状态
+     */
     val tunnelState: StateFlow<TunnelState?> = clashManager.tunnelState
 
+    /**
+     * 代理组信息（自动同步，无需手动刷新）
+     */
     val proxyGroups: StateFlow<List<ProxyGroupInfo>> = clashManager.proxyStateRepository.proxyGroups
 
+    /**
+     * 是否正在同步
+     */
     val isSyncing: StateFlow<Boolean> = clashManager.proxyStateRepository.isSyncing
 
+    /**
+     * 运行模式
+     */
     val runningMode: StateFlow<RunningMode> = clashManager.runningMode
 
+    /**
+     * 日志流
+     */
     val logs = clashManager.logs
 
+    // ========== 代理控制 ==========
+
+    /**
+     * 启动代理
+     *
+     * @param profileId 配置 ID
+     * @param forceTunMode 是否强制 TUN 模式
+     * @return 启动结果，成功时可能返回需要的 Intent（VPN 权限请求）
+     */
     suspend fun startProxy(profileId: String, forceTunMode: Boolean? = null): Result<Intent?> {
         return proxyConnectionService.prepareAndStart(profileId, forceTunMode)
     }
 
+    /**
+     * 停止代理
+     */
     fun stopProxy() {
         proxyConnectionService.stop(runningMode.value)
     }
 
+    // ========== 代理节点操作 ==========
+
+    /**
+     * 选择代理节点
+     *
+     * 注意：选择后状态会自动同步，无需手动刷新
+     *
+     * @param groupName 代理组名称
+     * @param proxyName 代理节点名称
+     * @return 是否成功
+     */
     suspend fun selectProxy(groupName: String, proxyName: String): Result<Boolean> {
         val result = clashManager.proxyStateRepository.selectProxy(groupName, proxyName)
 
         if (result.isSuccess && result.getOrNull() == true) {
+            // 保存选择到数据库
             val profile = currentProfile.value
             if (profile != null) {
                 try {
@@ -65,26 +151,67 @@ class ProxyFacade(
         return result
     }
 
+    /**
+     * 测试代理组延迟
+     *
+     * 注意：测试完成后状态会自动同步，无需手动刷新
+     *
+     * @param groupName 代理组名称
+     * @return 测试结果
+     */
     suspend fun testDelay(groupName: String): Result<Unit> {
         return clashManager.proxyStateRepository.testGroupDelay(groupName)
     }
 
+    /**
+     * 测试所有代理组延迟
+     *
+     * 注意：测试完成后状态会自动同步，无需手动刷新
+     *
+     * @return 测试结果
+     */
     suspend fun testAllDelay(): Result<Unit> {
         return clashManager.proxyStateRepository.testAllDelay()
     }
 
+    /**
+     * 获取节点延迟（从缓存）
+     *
+     * @param nodeName 节点名称
+     * @return 延迟值，null 表示未找到
+     */
     fun getCachedDelay(nodeName: String): Int? {
         return clashManager.proxyStateRepository.getCachedDelay(nodeName)
     }
 
+    // ========== 代理组查询 ==========
+
+    /**
+     * 查找代理组
+     *
+     * @param groupName 代理组名称
+     * @return 代理组信息，null 表示未找到
+     */
     fun findGroup(groupName: String): ProxyGroupInfo? {
         return clashManager.proxyStateRepository.findGroup(groupName)
     }
 
+    /**
+     * 获取当前选中的节点
+     *
+     * @param groupName 代理组名称
+     * @return 当前选中的节点名称
+     */
     fun getCurrentSelection(groupName: String): String? {
         return clashManager.proxyStateRepository.getCurrentSelection(groupName)
     }
 
+    /**
+     * 检查代理组是否可选择节点
+     *
+     * @param groupName 代理组名称
+     * @return 是否可选择（仅 Selector 类型）
+     */
     fun isSelectableGroup(groupName: String): Boolean {
         return clashManager.proxyStateRepository.isSelectableGroup(groupName)
     }

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/domain/model/HealthStatus.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/domain/model/HealthStatus.kt
@@ -1,0 +1,27 @@
+/*
+ * This file is part of YumeBox.
+ *
+ * YumeBox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Copyright (c)  YumeLira 2025.
+ *
+ */
+
+package com.github.yumelira.yumebox.domain.model
+
+data class HealthStatus(
+    val isHealthy: Boolean = true,
+    val lastCheckTime: Long = System.currentTimeMillis(),
+    val message: String? = null
+)

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/domain/model/ProxyState.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/domain/model/ProxyState.kt
@@ -25,6 +25,8 @@ import com.github.yumelira.yumebox.data.model.Profile
 sealed interface ProxyState {
     data object Idle : ProxyState
 
+    data class Preparing(val message: String = "正在准备...") : ProxyState
+
     data class Connecting(val mode: RunningMode) : ProxyState
 
     data class Running(
@@ -37,4 +39,10 @@ sealed interface ProxyState {
     data class Error(val message: String, val cause: Throwable? = null) : ProxyState
 
     val isRunning: Boolean get() = this is Running
+
+    val isTransitioning: Boolean get() = this is Preparing || this is Connecting || this is Stopping
+
+    val canStart: Boolean get() = this is Idle || this is Error
+
+    val canStop: Boolean get() = this is Running
 }

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/component/ConfigInput.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/component/ConfigInput.kt
@@ -136,7 +136,7 @@ fun StringListInput(
     onValueChange: (List<String>?) -> Unit,
 ) {
     val itemCount = value?.size ?: 0
-    val displayValue = if (itemCount > 0) "$itemCount 项" else "不修改"
+    val displayValue = if (itemCount > 0) "${itemCount} 项" else "不修改"
 
     SuperArrow(
         title = title,
@@ -163,7 +163,7 @@ fun StringMapInput(
     onValueChange: (Map<String, String>?) -> Unit,
 ) {
     val itemCount = value?.size ?: 0
-    val displayValue = if (itemCount > 0) "$itemCount 项" else "不修改"
+    val displayValue = if (itemCount > 0) "${itemCount} 项" else "不修改"
 
     SuperArrow(
         title = title,

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/screen/AppSettings.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/screen/AppSettings.kt
@@ -196,7 +196,7 @@ fun AppSettingsScreen(
                 Card {
                     BasicComponent(
                         title = "自定义 User-Agent",
-                        summary = customUserAgent.ifEmpty { "未设置，使用默认值" },
+                        summary = if (customUserAgent.isEmpty()) "未设置，使用默认值" else customUserAgent,
                         onClick = {
                             customUserAgentTextFieldState.value = TextFieldValue(customUserAgent)
                             showEditCustomUserAgentDialog.value = true

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/screen/Profiles.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/screen/Profiles.kt
@@ -70,6 +70,7 @@ import top.yukonga.miuix.kmp.icon.icons.useful.New
 import top.yukonga.miuix.kmp.icon.icons.useful.Refresh
 import top.yukonga.miuix.kmp.theme.MiuixTheme
 import java.io.File
+import java.util.*
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import kotlin.coroutines.resume
@@ -907,8 +908,25 @@ private fun AddProfileSheet(
                                                         show.value = false
                                                     } else {
                                                         scope.launch {
-                                                            isDownloading = false
-                                                           profilesViewModel.clearDownloadProgress()
+                                                            val profile = Profile(
+                                                                id = UUID.randomUUID().toString(),
+                                                                name = name.ifBlank { "新配置" },
+                                                                config = "",
+                                                                remoteUrl = url,
+                                                                type = ProfileType.URL,
+                                                                createdAt = System.currentTimeMillis(),
+                                                                updatedAt = System.currentTimeMillis()
+                                                            )
+
+                                                            val downloadedProfile =
+                                                                profilesViewModel.downloadProfile(
+                                                                    profile, saveToDb = true
+                                                                )
+                                                            if (downloadedProfile != null && downloadedProfile.config.isNotBlank()) {
+                                                            } else {
+                                                                isDownloading = false
+                                                                profilesViewModel.clearDownloadProgress()
+                                                            }
                                                         }
                                                     }
                                                 } else {

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/viewmodel/SettingViewModel.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/viewmodel/SettingViewModel.kt
@@ -29,7 +29,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 
 class SettingViewModel(
-    featureStore: FeatureStore,
+    private val featureStore: FeatureStore,
 ) : ViewModel() {
 
     val allowLanAccess = featureStore.allowLanAccess

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/viewmodel/TrafficStatisticsViewModel.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/viewmodel/TrafficStatisticsViewModel.kt
@@ -30,11 +30,13 @@ import com.github.yumelira.yumebox.data.model.TimeSlot
 import com.github.yumelira.yumebox.data.store.TrafficStatisticsStore
 import com.github.yumelira.yumebox.presentation.component.BarChartItem
 import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.*
 
 class TrafficStatisticsViewModel(
-    application: Application, private val trafficStatisticsStore: TrafficStatisticsStore
+    application: Application,
+    private val trafficStatisticsStore: TrafficStatisticsStore
 ) : AndroidViewModel(application) {
 
     private val _selectedTimeRange = MutableStateFlow(StatisticsTimeRange.TODAY)
@@ -43,24 +45,27 @@ class TrafficStatisticsViewModel(
     private val _selectedBarIndex = MutableStateFlow(-1)
     val selectedBarIndex: StateFlow<Int> = _selectedBarIndex.asStateFlow()
 
-    val todaySummary: StateFlow<DailyTrafficSummary> =
-        trafficStatisticsStore.dailySummaries.map { trafficStatisticsStore.getTodaySummary() }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DailyTrafficSummary.EMPTY)
+    val todaySummary: StateFlow<DailyTrafficSummary> = trafficStatisticsStore.dailySummaries
+        .map { trafficStatisticsStore.getTodaySummary() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DailyTrafficSummary.EMPTY)
 
-    val yesterdaySummary: StateFlow<DailyTrafficSummary> =
-        trafficStatisticsStore.dailySummaries.map { trafficStatisticsStore.getYesterdaySummary() }
-            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DailyTrafficSummary.EMPTY)
+    val yesterdaySummary: StateFlow<DailyTrafficSummary> = trafficStatisticsStore.dailySummaries
+        .map { trafficStatisticsStore.getYesterdaySummary() }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), DailyTrafficSummary.EMPTY)
 
-    val weekSummary: StateFlow<Long> = trafficStatisticsStore.dailySummaries.map {
+    val weekSummary: StateFlow<Long> = trafficStatisticsStore.dailySummaries
+        .map {
             trafficStatisticsStore.getDailySummaries(7).sumOf { it.total }
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0L)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0L)
 
     val trafficDifference: StateFlow<Long> = combine(todaySummary, yesterdaySummary) { today, yesterday ->
         today.total - yesterday.total
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), 0L)
 
     val chartItems: StateFlow<List<BarChartItem>> = combine(
-        _selectedTimeRange, trafficStatisticsStore.dailySummaries
+        _selectedTimeRange,
+        trafficStatisticsStore.dailySummaries
     ) { timeRange, _ ->
         when (timeRange) {
             StatisticsTimeRange.TODAY -> getTodayHourlyChartItems()
@@ -68,9 +73,13 @@ class TrafficStatisticsViewModel(
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    val profileUsages: StateFlow<List<ProfileTrafficUsage>> = trafficStatisticsStore.profileUsages.map { usages ->
-            usages.values.sortedByDescending { it.totalBytes }.take(10)
-        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    val profileUsages: StateFlow<List<ProfileTrafficUsage>> = trafficStatisticsStore.profileUsages
+        .map { usages ->
+            usages.values
+                .sortedByDescending { it.totalBytes }
+                .take(10)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     fun setTimeRange(range: StatisticsTimeRange) {
         _selectedTimeRange.value = range
@@ -89,7 +98,9 @@ class TrafficStatisticsViewModel(
         return TimeSlot.entries.map { slot ->
             val slotData = hourlyData.getOrNull(slot.ordinal)
             BarChartItem(
-                label = slot.label, value = slotData?.total ?: 0L, isHighlighted = slot == currentSlot
+                label = slot.label,
+                value = slotData?.total ?: 0L,
+                isHighlighted = slot == currentSlot
             )
         }
     }
@@ -107,7 +118,9 @@ class TrafficStatisticsViewModel(
                 dateFormat.format(calendar.time)
             }
             BarChartItem(
-                label = label, value = summary.total, isHighlighted = summary.dateMillis == todayKey
+                label = label,
+                value = summary.total,
+                isHighlighted = summary.dateMillis == todayKey
             )
         }
     }

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/webview/LocalWebView.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/webview/LocalWebView.kt
@@ -23,6 +23,7 @@ package com.github.yumelira.yumebox.presentation.webview
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.View
@@ -146,7 +147,9 @@ private fun createWebView(
 
             cacheMode = WebSettings.LOAD_DEFAULT
 
-            mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+            }
         }
 
         webViewClient = object : WebViewClient() {
@@ -197,7 +200,9 @@ private fun createWebView(
                 failingUrl: String?,
             ) {
                 @Suppress("DEPRECATION") super.onReceivedError(view, errorCode, description, failingUrl)
-                onPageError(failingUrl ?: "unknown", "Error $errorCode: $description")
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                    onPageError(failingUrl ?: "unknown", "Error $errorCode: $description")
+                }
             }
         }
 

--- a/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/webview/WebViewScreen.kt
+++ b/app/src/androidMain/kotlin/com/github/yumelira/yumebox/presentation/webview/WebViewScreen.kt
@@ -22,8 +22,8 @@ package com.github.yumelira.yumebox.presentation.webview
 
 import android.app.Activity
 import androidx.activity.compose.BackHandler
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import com.github.yumelira.yumebox.presentation.theme.ProvideAndroidPlatformTheme
 import com.github.yumelira.yumebox.presentation.theme.YumeTheme
@@ -48,7 +48,8 @@ fun WebViewScreen(
 
     ProvideAndroidPlatformTheme {
         YumeTheme(
-            themeMode = themeMode, colorTheme = colorTheme
+            themeMode = themeMode,
+            colorTheme = colorTheme
         ) {
             LocalWebView(initialUrl = initialUrl)
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -69,18 +69,18 @@ abstract class GitCommandValueSource : ValueSource<String, GitCommandValueSource
     }
 }
 
-val mimeDir: Directory? = layout.projectDirectory.dir("src/foss/golang/mihomo")
+val mihomoDir = layout.projectDirectory.dir("src/foss/golang/mihomo")
 
 val gitCommitProvider: Provider<String> = providers.of(GitCommandValueSource::class) {
     parameters {
-        workingDir.set(mimeDir)
+        workingDir.set(mihomoDir)
         args.set(listOf("rev-parse", "--short", "HEAD"))
     }
 }
 
 val gitBranchProvider: Provider<String> = providers.of(GitCommandValueSource::class) {
     parameters {
-        workingDir.set(mimeDir)
+        workingDir.set(mihomoDir)
         args.set(listOf("branch", "--show-current"))
     }
 }

--- a/core/src/cpp/version.h
+++ b/core/src/cpp/version.h
@@ -6,7 +6,7 @@
  * 当前编译core版本号
  */
 
-#define GIT_VERSION Alpha-498f81aa
+#define GIT_VERSION Alpha-9168bee6
 #define make_Str(x) #x
 #define make_String(x) make_Str(x)
 

--- a/core/src/kotlin/com/github/yumelira/yumebox/core/Clash.kt
+++ b/core/src/kotlin/com/github/yumelira/yumebox/core/Clash.kt
@@ -27,6 +27,9 @@ object Clash {
         Bridge.nativeReset()
     }
 
+    fun forceGc() {
+        Bridge.nativeForceGc()
+    }
 
     fun suspendCore(suspended: Boolean) {
         Bridge.nativeSuspend(suspended)
@@ -43,7 +46,19 @@ object Clash {
 
     fun queryTrafficTotal(): Traffic {
         return Bridge.nativeQueryTrafficTotal()
+    }
 
+    fun notifyDnsChanged(dns: List<String>) {
+        Bridge.nativeNotifyDnsChanged(dns.toSet().joinToString(separator = ","))
+    }
+
+    fun notifyTimeZoneChanged(name: String, offset: Int) {
+        Bridge.nativeNotifyTimeZoneChanged(name, offset)
+    }
+
+    fun notifyInstalledAppsChanged(uids: List<Pair<Int, String>>) {
+        val uidList = uids.joinToString(separator = ",") { "${it.first}:${it.second}" }
+        Bridge.nativeNotifyInstalledAppChanged(uidList)
     }
 
     fun startTun(

--- a/core/src/kotlin/com/github/yumelira/yumebox/core/Global.kt
+++ b/core/src/kotlin/com/github/yumelira/yumebox/core/Global.kt
@@ -14,5 +14,9 @@ object Global : CoroutineScope by CoroutineScope(Dispatchers.IO) {
     fun init(application: Application) {
         _application = application
     }
+
+    fun destroy() {
+        cancel()
+    }
 }
 

--- a/core/src/kotlin/com/github/yumelira/yumebox/core/bridge/Content.kt
+++ b/core/src/kotlin/com/github/yumelira/yumebox/core/bridge/Content.kt
@@ -1,6 +1,6 @@
 package com.github.yumelira.yumebox.core.bridge
 
-import android.net.Uri.parse
+import android.net.Uri
 import androidx.annotation.Keep
 import com.github.yumelira.yumebox.core.Global
 import java.io.FileNotFoundException
@@ -9,7 +9,7 @@ import java.io.FileNotFoundException
 object Content {
     @JvmStatic
     fun open(url: String): Int {
-        val uri = parse(url)
+        val uri = Uri.parse(url)
 
         if (uri.scheme != "content") {
             throw UnsupportedOperationException("Unsupported scheme ${uri.scheme}")

--- a/core/src/kotlin/com/github/yumelira/yumebox/core/util/Traffic.kt
+++ b/core/src/kotlin/com/github/yumelira/yumebox/core/util/Traffic.kt
@@ -49,3 +49,16 @@ private fun trafficString(scaled: Long): String {
         }
     }
 }
+
+private fun scaleTraffic(value: Long): Long {
+    val type = (value ushr 30) and 0x3
+    val data = value and 0x3FFFFFFF
+
+    return when (type) {
+        0L -> data
+        1L -> data * 1024
+        2L -> data * 1024 * 1024
+        3L -> data * 1024 * 1024 * 1024
+        else -> throw IllegalArgumentException("invalid value type")
+    }
+}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,26 +1,10 @@
 ####################################################################################################################
 # WARNING: Do not store sensitive information in this file, as its contents will be included in the Qodana report. #
 ####################################################################################################################
+
 version: "1.0"
 linter: jetbrains/qodana-jvm-android:2025.2
 profile:
   name: qodana.recommended
 include:
   - name: CheckDependencyLicenses
-exclude:
-  - name: All
-    paths:
-      - app\src\androidMain\kotlin\com\github\yumelira\yumebox\presentation\icon\yume
-      - app\src\androidMain\res\drawable
-      - app\src\androidMain\res
-      - core
-      - build-logic
-      - app/src/androidMain/res
-      - app\src\androidMain\kotlin\com\github\yumelira\yumebox\presentation\icon
-  - name: AndroidLintVectorRaster
-  - name: AndroidLintVectorPath
-  - name: AndroidLintUseKtx
-  - name: AndroidLintIconLocation
-  - name: AndroidLintMonochromeLauncherIcon
-    paths:
-      - .idea\modules\app


### PR DESCRIPTION
Reverts YumeLira/YumeBox#45

## Summary by Sourcery

Reintroduce previously removed core proxy, profile, and traffic-related functionality and associated utilities, effectively reverting an earlier refactor.

New Features:
- Restore extended Clash core APIs for GC, DNS/timezone change notifications, and installed apps updates.
- Reintroduce proxy health and state models, including a Preparing state and health status tracking.
- Add explicit enabled-profile tracking and querying in the profiles store and repository.

Bug Fixes:
- Fix WebView configuration and error handling for different Android API levels when loading local content.
- Correct profile download flow to create and persist URL-based profiles before attempting downloads.
- Ensure release build signing configuration directly references the release signingConfig to avoid null resolution issues.

Enhancements:
- Expand proxy facade to expose detailed state flows and proxy group operations for the UI layer.
- Refine traffic statistics view model flows and profile usage aggregation for clearer state handling.
- Improve global coroutine scope lifecycle management with an explicit destroy hook.
- Tighten app settings and configuration inputs display logic for clearer summaries and counts.
- Adjust Gradle and Qodana configuration to align with restored core layout and analysis settings.

Build:
- Update core Gradle configuration to use the correct mihomo source directory for Git metadata.
- Simplify app module signing config usage by directly referencing the release signing config.

Chores:
- Update embedded core version identifier to a newer commit hash.