### PR TITLE
Improve Home start button and pager swipe feel

### DIFF
--- a/app/src/main/kotlin/com/github/yumelira/yumebox/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/yumelira/yumebox/MainActivity.kt
@@ -29,6 +29,7 @@ import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.rememberSplineBasedDecay
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.pager.HorizontalPager
@@ -181,6 +182,15 @@ fun MainScreen(navigator: DestinationsNavigator) {
         backgroundColor = MiuixTheme.colorScheme.background,
         tint = HazeTint(MiuixTheme.colorScheme.background.copy(0.8f)),
     )
+    val pageChangeAnimationSpec = remember {
+        spring(dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessLow)
+    }
+    val pagerDecaySpec = rememberSplineBasedDecay<Float>()
+    val pagerFlingBehavior = PagerDefaults.flingBehavior(
+        state = pagerState,
+        snapAnimationSpec = pageChangeAnimationSpec,
+        decayAnimationSpec = pagerDecaySpec
+    )
 
     val appSettingsViewModel = koinViewModel<AppSettingsViewModel>()
     val bottomBarAutoHide by appSettingsViewModel.bottomBarAutoHide.state.collectAsState()
@@ -189,9 +199,8 @@ fun MainScreen(navigator: DestinationsNavigator) {
         { page ->
             coroutineScope.launch {
                 pagerState.animateScrollToPage(
-                    page = page, animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMedium
-                    )
+                    page = page,
+                    animationSpec = pageChangeAnimationSpec
                 )
             }
         }
@@ -201,9 +210,8 @@ fun MainScreen(navigator: DestinationsNavigator) {
         if (pagerState.currentPage != 0) {
             coroutineScope.launch {
                 pagerState.animateScrollToPage(
-                    page = 0, animationSpec = spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMedium
-                    )
+                    page = 0,
+                    animationSpec = pageChangeAnimationSpec
                 )
             }
         } else {
@@ -236,16 +244,12 @@ fun MainScreen(navigator: DestinationsNavigator) {
                     .hazeSource(state = hazeState)
                     .nestedScroll(bottomBarScrollBehavior.nestedScrollConnection),
                 state = pagerState,
-                beyondViewportPageCount = 1,
+                beyondViewportPageCount = 2,
                 userScrollEnabled = true,
                 pageNestedScrollConnection = PagerDefaults.pageNestedScrollConnection(
                     state = pagerState, orientation = androidx.compose.foundation.gestures.Orientation.Horizontal
                 ),
-                flingBehavior = PagerDefaults.flingBehavior(
-                    state = pagerState, snapAnimationSpec = spring(
-                        dampingRatio = Spring.DampingRatioNoBouncy, stiffness = Spring.StiffnessMedium
-                    )
-                ),
+                flingBehavior = pagerFlingBehavior,
             ) { page ->
                 when (page) {
                     0 -> HomePager(innerPadding)

--- a/app/src/main/kotlin/com/github/yumelira/yumebox/presentation/screen/home/ProxyControlButton.kt
+++ b/app/src/main/kotlin/com/github/yumelira/yumebox/presentation/screen/home/ProxyControlButton.kt
@@ -7,12 +7,15 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.github.yumelira.yumebox.common.AppConstants
 import com.github.yumelira.yumebox.presentation.icon.Yume
@@ -54,8 +57,17 @@ fun ProxyControlButton(
         label = "CornerRadius"
     )
 
-    MiuixTheme.colorScheme.surface
-    MiuixTheme.colorScheme.onSurface
+    val iconScale by animateFloatAsState(
+        targetValue = if (isRunning) 0.92f else 1f,
+        animationSpec = tween(
+            durationMillis = 240,
+            easing = FastOutSlowInEasing
+        ),
+        label = "IconScale"
+    )
+
+    val buttonShape = androidx.compose.foundation.shape.RoundedCornerShape(animatedCornerRadius)
+    val buttonLabel = if (isRunning) "停止" else "启动"
 
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -75,23 +87,35 @@ fun ProxyControlButton(
                 .fillMaxWidth(animatedWidthFraction)
                 .shadow(
                     elevation = 1.dp,
-                    shape = androidx.compose.foundation.shape.RoundedCornerShape(animatedCornerRadius),
+                    shape = buttonShape,
                     clip = false
                 )
                 .border(
                     width = 0.2.dp,
                     color = MiuixTheme.colorScheme.outline,
-                    shape = androidx.compose.foundation.shape.RoundedCornerShape(animatedCornerRadius)
+                    shape = buttonShape
                 ),
             colors = ButtonDefaults.buttonColors(MiuixTheme.colorScheme.background),
             cornerRadius = animatedCornerRadius,
-            minHeight = 36.dp
+            minHeight = 44.dp
         ) {
-            Icon(
-                imageVector = if (isRunning) Yume.Square else Yume.Play,
-                contentDescription = null,
-                tint = MiuixTheme.colorScheme.onSurface
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Icon(
+                    imageVector = if (isRunning) Yume.Square else Yume.Play,
+                    contentDescription = null,
+                    tint = MiuixTheme.colorScheme.onSurface,
+                    modifier = Modifier.scale(iconScale)
+                )
+                Text(
+                    text = buttonLabel,
+                    style = MiuixTheme.textStyles.body2,
+                    color = MiuixTheme.colorScheme.onSurface,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
         }
 
 


### PR DESCRIPTION
### Motivation
- Make the Home screen start/stop control more readable and provide clearer touch feedback for users. 
- Reduce janky or overly stiff horizontal pager swipes so navigation feels smoother and more natural. 
- Keep UI behavior consistent with existing design tokens (corner radius, spacing) while improving affordance and animation.

### Description
- Updated `ProxyControlButton` (`app/src/main/kotlin/.../home/ProxyControlButton.kt`) to add a visible label (`"启动"`/`"停止"`), animate the icon scale, increase the button `minHeight` to `44.dp`, and reuse a single `RoundedCornerShape` for shadow/border so visuals remain consistent.
- Tuned pager swipe behavior in `MainActivity` (`app/src/main/kotlin/com/github/yumelira/yumebox/MainActivity.kt`) by introducing a low-stiffness `spring` as the page change animation, using `rememberSplineBasedDecay` for decay, and wiring a `pagerFlingBehavior` via `PagerDefaults.flingBehavior` for improved fling/decay handling.
- Increased `HorizontalPager` `beyondViewportPageCount` from `1` to `2` and unified `animateScrollToPage` calls to use the shared `pageChangeAnimationSpec` to preload pages and make programmatic page changes feel consistent with user gestures.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e167a7964832db9d4938009d85c90)

## Summary by Sourcery

Refine the Home proxy control button and horizontal pager interactions to improve readability, touch feedback, and swipe feel.

New Features:
- Add a labeled start/stop proxy control button that displays a localized text label alongside the icon.

Enhancements:
- Animate the proxy control icon scale and increase button minimum height to improve tactile feedback and accessibility.
- Reuse a shared rounded corner shape for the proxy control button’s shadow and border to keep visuals consistent.
- Introduce a shared low-stiffness spring spec and decay-based fling behavior for the main HorizontalPager to create smoother, more natural page transitions.
- Increase the HorizontalPager beyond-viewport page count and unify programmatic page transitions to use the shared animation spec for more consistent navigation behavior.