### PR TITLE
Reduce proxy node update churn further

### DIFF
--- a/app/src/main/kotlin/com/github/yumelira/yumebox/presentation/component/ProxyNodeGrid.kt
+++ b/app/src/main/kotlin/com/github/yumelira/yumebox/presentation/component/ProxyNodeGrid.kt
@@ -24,8 +24,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.github.yumelira.yumebox.core.model.Proxy
@@ -36,13 +37,23 @@ fun ProxyNodeGrid(
     proxies: List<Proxy>,
     selectedProxyName: String,
     displayMode: ProxyDisplayMode,
-    onProxyClick: ((Proxy) -> Unit)? = null,
-    onProxyDelayClick: ((Proxy) -> Unit)? = null,
+    onProxyClick: ((String) -> Unit)? = null,
+    onProxyDelayClick: ((String) -> Unit)? = null,
     isDelayTesting: Boolean = false,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp)
 ) {
     val columns = if (displayMode.isSingleColumn) 1 else 2
+    val maxAnimatedPills = if (proxies.size <= 40) {
+        proxies.size
+    } else {
+        12
+    }
+    val contentType = when {
+        displayMode.isSingleColumn -> "single"
+        displayMode.showDetail -> "detail"
+        else -> "compact"
+    }
 
     LazyVerticalGrid(
         columns = GridCells.Fixed(columns),
@@ -51,18 +62,30 @@ fun ProxyNodeGrid(
         horizontalArrangement = Arrangement.spacedBy(12.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        items(
+        itemsIndexed(
             items = proxies,
-            key = { it.name },
-        ) { proxy ->
+            key = { _, proxy -> proxy.name },
+            contentType = { _, _ -> contentType },
+        ) { index, proxy ->
+            val proxyName = proxy.name
+            val onClick = onProxyClick?.let { handler ->
+                remember(proxyName, handler) { { handler(proxyName) } }
+            }
+            val onDelayClick = onProxyDelayClick?.let { handler ->
+                remember(proxyName, handler) { { handler(proxyName) } }
+            }
+            val isLoading = isDelayTesting && index < maxAnimatedPills
             ProxyNodeCard(
-                proxy = proxy,
+                name = proxyName,
+                typeName = proxy.type.name,
+                delay = proxy.delay,
                 isSelected = proxy.name == selectedProxyName,
-                onClick = onProxyClick?.let { { it(proxy) } },
+                onClick = onClick,
                 isSingleColumn = displayMode.isSingleColumn,
                 showDetail = displayMode.showDetail,
-                onDelayClick = onProxyDelayClick?.let { { it(proxy) } },
-                isDelayTesting = isDelayTesting,
+                onDelayClick = onDelayClick,
+                isDelayTesting = isLoading,
+                enableLoadingAnimation = isLoading,
             )
         }
     }

--- a/app/src/main/kotlin/com/github/yumelira/yumebox/presentation/screen/Proxy.kt
+++ b/app/src/main/kotlin/com/github/yumelira/yumebox/presentation/screen/Proxy.kt
@@ -361,9 +361,9 @@ private fun ProxyGroupSelectorContent(
                 selectedProxyName = group.now,
                 displayMode = displayMode,
                 onProxyClick = onProxyClick?.let { click ->
-                    { proxy: Proxy -> click(proxy.name) }
+                    { proxyName: String -> click(proxyName) }
                 },
-                onProxyDelayClick = { onGroupDelayClick() },
+                onProxyDelayClick = { _ -> onGroupDelayClick() },
                 isDelayTesting = isGroupTesting,
                 contentPadding = PaddingValues(top = 12.dp, bottom = 16.dp),
                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
### Motivation
- Reduce unnecessary recompositions and lambda/object allocations in the proxy list UI to improve performance when many items are present.
- Limit continuous per-item animations during delay testing to reduce CPU/GPU pressure and visual churn.
- Make callbacks and content types stable so `Lazy` can skip unchanged items where possible.

### Description
- Change `ProxyNodeCard` to accept primitive fields (`name`, `typeName`, `delay`) instead of a `Proxy` object to avoid passing potentially unstable objects into item composables and reduce churn.  
- Memoize delay pill styling with `remember(delay)` via a new `DelayPillStyle` data class and avoid computing style/text each recomposition.  
- Avoid allocating `MutableInteractionSource` when a pill/card is not clickable by only creating it when `onClick != null`.  
- Update `ProxyNodeGrid` to use `itemsIndexed` with a stable `key` and `contentType`, cache per-item click handlers with `remember(proxyName, handler) { { handler(proxyName) } }`, compute `maxAnimatedPills`, and mark only a small subset as loading (`isLoading = isDelayTesting && index < maxAnimatedPills`) and enable animations only for that subset (`enableLoadingAnimation = isLoading`).  
- Adjust call sites (`Proxy.kt`) to the new callback signatures (`(String) -> Unit`) and to the new `ProxyNodeCard` parameter list.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fb0495114832d836178354c8fdd96)

## Summary by Sourcery

Optimize proxy list UI composables to reduce recompositions and animation churn, improving performance for large proxy lists.

Enhancements:
- Make ProxyNodeCard accept primitive proxy fields instead of a Proxy object to keep item content stable for Lazy grids.
- Memoize delay pill styling and text based on delay and avoid interaction sources when not clickable to reduce allocations and recompositions.
- Limit delay testing animations to a small subset of proxy items and add a flag to toggle loading animation separately from loading state.
- Use itemsIndexed with stable keys and shared content types in ProxyNodeGrid and cache per-item click handlers by proxy name.
- Update proxy screen callbacks to operate on proxy names instead of Proxy instances for more lightweight interactions.