### PR TITLE
Add license and copyright comments to Rocket.kt

### DIFF
--- a/app/src/main/kotlin/com/github/yumelira/yumebox/presentation/icon/yume/Rocket.kt
+++ b/app/src/main/kotlin/com/github/yumelira/yumebox/presentation/icon/yume/Rocket.kt
@@ -1,3 +1,25 @@
+/*
+ * This file is part of YumeBox.
+ *
+ * YumeBox is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * Copyright (c)  YumeLira 2026.
+ *
+ */
+
+package com.github.yumelira.yumebox.presentation.icon.yume
+
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.StrokeCap


### PR DESCRIPTION
Added licensing information and copyright notice to Rocket.kt

## Summary by Sourcery

Chores:
- Align Rocket.kt with project licensing by adding AGPL license header and copyright metadata.