### PR TITLE
Remove theme override from feature:web manifest activity

### DIFF
--- a/feature/web/src/main/AndroidManifest.xml
+++ b/feature/web/src/main/AndroidManifest.xml
@@ -5,7 +5,6 @@
             android:name="com.github.yumelira.yumebox.WebViewActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:exported="false"
-            android:hardwareAccelerated="true"
-            android:theme="@style/Theme.YumeBox" />
+            android:hardwareAccelerated="true" />
     </application>
 </manifest>


### PR DESCRIPTION
### Motivation
- The `feature:web` library's activity referenced an app-only style which can break AAPT resource linking during library resource verification, so the manifest should not depend on app-defined themes.

### Description
- Removed the `android:theme` attribute from `feature/web/src/main/AndroidManifest.xml` on `com.github.yumelira.yumebox.WebViewActivity`, leaving other activity attributes unchanged.

### Testing
- Ran `./gradlew :feature:web:verifyReleaseResources --no-daemon`, but the build aborted during configuration because a Java 17 toolchain could not be found, so full resource verification could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c86526d88832d96ae52d45dcf8c1f)