### PR TITLE
fix: correct internal link path Chinese override page

### DIFF
--- a/website/override/index.mdx
+++ b/website/override/index.mdx
@@ -298,7 +298,7 @@ Map 类型使用 `-merge` 合并键值对。
 
 ## 支持覆写的字段
 
-完整字段清单见：[字段清单](/cn/override/fields)
+完整字段清单见：[字段清单](/override/fields)
 
 常见可覆写字段：
 


### PR DESCRIPTION
- Corrected internal link path on the Chinese override page to point to the proper target.